### PR TITLE
fix: static builds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -54,6 +54,9 @@ const config = {
     patchWasmModuleImport(config, options.isServer);
     return config;
   },
+  assetPrefix: "./",
 };
+
+
 
 export default config;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,11 +6,11 @@ import { createWeb3Modal, defaultWagmiConfig } from "@web3modal/wagmi/react";
 import Navbar from "@/components/layout/Navbar";
 import { ThemeProvider } from "@/components/ui/theme-provider";
 import Footer from "@/components/layout/Footer";
-import { Mulish } from "next/font/google";
+// import { Mulish } from "next/font/google";
 import Head from "next/head";
 import "@/styles/globals.css";
 
-const font = Mulish({ subsets: ["latin"] });
+// const font = Mulish({ subsets: ["latin"] });
 const PROJECT_ID = process.env.NEXT_PUBLIC_PROJECT_ID ?? "";
 
 const chains = [mainnet];
@@ -24,12 +24,13 @@ const MyApp: AppType = ({
 }) => {
   return (
     <WagmiConfig config={wagmiConfig}>
-      <main className={font.className}>
+      {/* <main className={font.className}> */}
+      <main>
         <Head>
-          <link rel="icon" href="/ceramic-favicon.svg" />
-          <meta property="og:image" content="/ceramic-favicon.svg" />
+          <link rel="icon" href="./ceramic-favicon.svg" />
+          <meta property="og:image" content="./ceramic-favicon.svg" />
           <meta property="og:type" content="website" />
-          <meta name="twitter:image" content="/ceramic-favicon.svg" />
+          <meta name="twitter:image" content="./ceramic-favicon.svg" />
         </Head>
         <ThemeProvider>
           <Navbar />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,7 +27,7 @@ export default function Home() {
       <Head>
         <title>Private Data Playground</title>
         <meta name="description" content="" />
-        <link rel="icon" href="/ceramic-favicon.svg" />
+        <link rel="icon" href="./ceramic-favicon.svg" />
         <meta property="og:title" content="" />
         <meta property="og:description" content="" />
       </Head>


### PR DESCRIPTION
I wanted to make sure that the static builds generated could be uploaded and accessed from IPFS/ENS. To ensure that would work it should be possible to access the page directly from the filesystem, e.g. `file:///Users/joel/code/private-data-playground/out/index.html`.

To enable this I had to add `assetPrefix: "./",`. Unfortunately this wasn't compatible with `next/font` so they need to be disabled. Maybe there's another way to set fonts?